### PR TITLE
Loosened bytestrings version constraint

### DIFF
--- a/wire-streams.cabal
+++ b/wire-streams.cabal
@@ -22,7 +22,7 @@ library
   exposed-modules:      System.IO.Streams.Binary
   build-depends:        base == 4.*
                     ,   binary == 0.8.*
-                    ,   bytestring == 0.10.*
+                    ,   bytestring >= 0.10
                     ,   binary-parsers >= 0.2.1
                     ,   io-streams >= 1.2
 


### PR DESCRIPTION
This allows this library to be used with GHC 9.2